### PR TITLE
Switch security.adoc to a markdown file so the security policy will show up for new issues

### DIFF
--- a/SECURITY.adoc
+++ b/SECURITY.adoc
@@ -1,6 +1,0 @@
-= Security Policy
-
-== Reporting a Vulnerability
-
-If you think you have found a security vulnerability, please **DO NOT** disclose it publicly until we’ve had a chance to fix it.
-Please don’t report security vulnerabilities using GitHub issues, instead head over to https://micrometer.io/security-policy and learn how to disclose them responsibly.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,6 @@
+# Security Policy
+
+## Reporting a Vulnerability
+
+If you think you have found a security vulnerability, please **DO NOT** disclose it publicly until we’ve had a chance to fix it.
+Please don’t report security vulnerabilities using GitHub issues, instead head over to [Micrometer Security Policy](https://micrometer.io/security-policy) and learn how to disclose them responsibly.


### PR DESCRIPTION
Switching to a markdown file will allow the security policy to show up as an option when creating new issues.  
See https://docs.github.com/en/code-security/getting-started/adding-a-security-policy-to-your-repository 

Resolves #1 